### PR TITLE
Bump upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Bumped `azuredisk-csi` to upstream version 1.16.0.
+- Bumped `csi-provisioner` to upstream version 3.4.0.
+- Bumped `livenessprobe` to upstream version 2.6.0.
+- Bumped `csi-node-driver-registrar` to upstream version 2.5.0.
+
 ## [1.13.0-gs2] - 2022-03-21
 
 ### Added

--- a/helm/azuredisk-csi-driver-app/Chart.yaml
+++ b/helm/azuredisk-csi-driver-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.13.0
+appVersion: 1.16.0
 description: A Helm chart to run Azure CSI driver for Azure Disks.
 home: https://github.com/giantswarm/azuredisk-csi-driver-app
 name: azuredisk-csi-driver-app

--- a/helm/azuredisk-csi-driver-app/values.yaml
+++ b/helm/azuredisk-csi-driver-app/values.yaml
@@ -9,11 +9,11 @@ image:
   baseRepo: quay.io/giantswarm/
   azuredisk:
     repository: azuredisk-csi
-    tag: v1.13.0
+    tag: v1.16.0
     pullPolicy: IfNotPresent
   csiProvisioner:
     repository: csi-provisioner
-    tag: v3.1.0
+    tag: v3.4.0
     pullPolicy: IfNotPresent
   csiAttacher:
     repository: csi-attacher
@@ -25,11 +25,11 @@ image:
     pullPolicy: IfNotPresent
   livenessProbe:
     repository: livenessprobe
-    tag: v2.5.0
+    tag: v2.6.0
     pullPolicy: IfNotPresent
   nodeDriverRegistrar:
     repository: csi-node-driver-registrar
-    tag: v2.4.0
+    tag: v2.5.0
     pullPolicy: IfNotPresent
 
 serviceAccount:


### PR DESCRIPTION
- Bumped `azuredisk-csi` to upstream version 1.16.0.
- Bumped `csi-provisioner` to upstream version 3.4.0.
- Bumped `livenessprobe` to upstream version 2.6.0.
- Bumped `csi-node-driver-registrar` to upstream version 2.5.0.