### PR TITLE
Bump upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped `azuredisk-csi` to upstream version 1.19.0.
+- Bumped `csi-provisioner` to upstream version 3.2.0.
+- Bumped `csi-attacher` to upstream version 3.5.0.
+- Bumped `csi-resizer` to upstream version 1.5.0.
+- Bumped `livenessprobe` to upstream version 2.5.0.
+- Bumped `csi-node-driver-registrar` to upstream version 2.5.1.
+- Update helm chart templates from upstream.
+
 ## [1.16.1] - 2022-06-15
 
 ### Changed

--- a/helm/azuredisk-csi-driver-app/Chart.yaml
+++ b/helm/azuredisk-csi-driver-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.16.0
+appVersion: 1.19.0
 description: A Helm chart to run Azure CSI driver for Azure Disks.
 home: https://github.com/giantswarm/azuredisk-csi-driver-app
 name: azuredisk-csi-driver-app

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/deployment.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/deployment.yaml
@@ -46,6 +46,7 @@ spec:
             - "--v=2"
             - "--timeout=15s"
             - "--leader-election"
+            - "--leader-election-namespace={{ .Release.Namespace }}"
             - "--worker-threads={{ .Values.controller.provisionerWorkerThreads }}"
             - "--extra-create-metadata=true"
             - "--strict-topology=true"
@@ -63,6 +64,7 @@ spec:
             - "-csi-address=$(ADDRESS)"
             - "-timeout=600s"
             - "-leader-election"
+            - "--leader-election-namespace={{ .Release.Namespace }}"
             - "-worker-threads={{ .Values.controller.attacherWorkerThreads }}"
           env:
             - name: ADDRESS
@@ -90,9 +92,10 @@ spec:
             - "-csi-address=$(ADDRESS)"
             - "-v=2"
             - "-leader-election"
+            - "--leader-election-namespace={{ .Release.Namespace }}"
             - '-handle-volume-inuse-error=false'
             - '-feature-gates=RecoverVolumeExpansionFailure=true'
-            - "-timeout=120s"
+            - "-timeout=240s"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-node/daemonset.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-node/daemonset.yaml
@@ -90,6 +90,8 @@ spec:
             - "--custom-user-agent={{ .Values.driver.customUserAgent }}"
             - "--user-agent-suffix={{ .Values.driver.userAgentSuffix }}"
             - "--allow-empty-cloud-config={{ .Values.node.allowEmptyCloudConfig }}"
+            - "--support-zone=true"
+            - "--get-node-info-from-labels=false"
           ports:
             - containerPort: {{ .Values.node.livenessProbe.healthPort }}
               name: healthz

--- a/helm/azuredisk-csi-driver-app/templates/snapshot-controller/deployment.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/snapshot-controller/deployment.yaml
@@ -40,6 +40,7 @@ spec:
           args:
             - "--v=2"
             - "--leader-election=true"
+            - "--leader-election-namespace={{ .Release.Namespace }}"
           resources: {{- toYaml .Values.snapshot.snapshotController.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.snapshot.image.csiSnapshotController.pullPolicy }}
 {{- end -}}

--- a/helm/azuredisk-csi-driver-app/values.yaml
+++ b/helm/azuredisk-csi-driver-app/values.yaml
@@ -9,27 +9,27 @@ image:
   baseRepo: quay.io/giantswarm/
   azuredisk:
     repository: azuredisk-csi
-    tag: v1.16.0
+    tag: v1.19.0
     pullPolicy: IfNotPresent
   csiProvisioner:
     repository: csi-provisioner
-    tag: v3.1.0
+    tag: v3.2.0
     pullPolicy: IfNotPresent
   csiAttacher:
     repository: csi-attacher
-    tag: v3.4.0
+    tag: v3.5.0
     pullPolicy: IfNotPresent
   csiResizer:
     repository: csi-resizer
-    tag: v1.4.0
+    tag: v1.5.0
     pullPolicy: IfNotPresent
   livenessProbe:
     repository: livenessprobe
-    tag: v2.6.0
+    tag: v2.7.0
     pullPolicy: IfNotPresent
   nodeDriverRegistrar:
     repository: csi-node-driver-registrar
-    tag: v2.5.0
+    tag: v2.5.1
     pullPolicy: IfNotPresent
 
 serviceAccount:


### PR DESCRIPTION
- Bumped `azuredisk-csi` to upstream version 1.19.0.
- Bumped `csi-provisioner` to upstream version 3.2.0.
- Bumped `csi-attacher` to upstream version 3.5.0.
- Bumped `csi-resizer` to upstream version 1.5.0.
- Bumped `livenessprobe` to upstream version 2.5.0.
- Bumped `csi-node-driver-registrar` to upstream version 2.5.1.
- Update helm chart templates from upstream.