### PR TITLE
Add NetworkPolicy to make app compatible with workload clusters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Push app to default catalog.
 
+### Added
+
+- Add NetworkPolicy to make app compatible with workload clusters.
+
 ## [1.21.0-gs1] - 2022-08-11
 
 ### Changed

--- a/helm/azuredisk-csi-driver-app/templates/snapshot-controller/network-policy.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/snapshot-controller/network-policy.yaml
@@ -1,0 +1,16 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ .Values.snapshot.snapshotController.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.snapshot.snapshotController.name }}
+    app.kubernetes.io/component: "snapshotController"
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Values.snapshot.snapshotController.name }}
+  egress:
+  - {}
+  policyTypes:
+  - Egress


### PR DESCRIPTION
In order to run this app in WCs we need to add a network policy