### PR TITLE
Upgrade to upstream 1.25.0 and sync Helm chart for missing features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Add support for http/s proxy settings to azuredisk using `cluster-apps-operator` `cluster.proxy` values
 - as per [KEP 2067](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md#renaming-the-node-rolekubernetesiomaster-node-label) add toleration for `node-role.kubernetes.io/control-plane` label and update nodeSelector
 - add rbac to get nodes for azuredisk-node to match upstream
+- Make some hardcoded fields in the template a value so that we can set them differently in `Vintage` and in `CAPZ`
+  - runOnMaster nodeSelector label
+  - AZURE_CREDENTIAL_FILE location
 
 ## [1.21.0-gs4] - 2022-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+- Bumped `azuredisk-csi` to upstream version 1.25.0
+- Increased qps limits for csi-provisioner and csi-attacher to match upstream
+- Increased WorkerThreads for csi-provisioner to match upstream
+- Increased csi-attacher timeout from 600s to 1200s to match upstream
+- Add support for http/s proxy settings to azuredisk
+- as per [KEP 2067](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md#renaming-the-node-rolekubernetesiomaster-node-label) add toleration for `node-role.kubernetes.io/control-plane` label and update nodeSelector
+- add rbac to get nodes for azuredisk-node to match upstream
+
 ## [1.21.0-gs4] - 2022-08-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Increased qps limits for csi-provisioner and csi-attacher to match upstream
 - Increased WorkerThreads for csi-provisioner to match upstream
 - Increased csi-attacher timeout from 600s to 1200s to match upstream
-- Add support for http/s proxy settings to azuredisk
+- Add support for http/s proxy settings to azuredisk using `cluster-apps-operator` `cluster.proxy` values
 - as per [KEP 2067](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md#renaming-the-node-rolekubernetesiomaster-node-label) add toleration for `node-role.kubernetes.io/control-plane` label and update nodeSelector
 - add rbac to get nodes for azuredisk-node to match upstream
 

--- a/helm/azuredisk-csi-driver-app/Chart.yaml
+++ b/helm/azuredisk-csi-driver-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.19.0
+appVersion: 1.25.0
 description: A Helm chart to run Azure CSI driver for Azure Disks.
 icon: https://s.giantswarm.io/app-icons/azure/1/dark.svg
 home: https://github.com/giantswarm/azuredisk-csi-driver-app

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/deployment.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
         {{- if .Values.controller.runOnMaster}}
-        kubernetes.io/role: master
+        node-role.kubernetes.io/control-plane: ""
         {{- end}}
       priorityClassName: system-cluster-critical
 {{- with .Values.controller.tolerations }}
@@ -50,6 +50,8 @@ spec:
             - "--worker-threads={{ .Values.controller.provisionerWorkerThreads }}"
             - "--extra-create-metadata=true"
             - "--strict-topology=true"
+            - "--kube-api-qps=50"
+            - "--kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -62,10 +64,12 @@ spec:
           args:
             - "-v=2"
             - "-csi-address=$(ADDRESS)"
-            - "-timeout=600s"
+            - "-timeout=1200s"
             - "-leader-election"
             - "--leader-election-namespace={{ .Release.Namespace }}"
             - "-worker-threads={{ .Values.controller.attacherWorkerThreads }}"
+            - "-kube-api-qps=50"
+            - "-kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -147,6 +151,18 @@ spec:
               value: /etc/kubernetes/config/azure.yaml
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
+            {{- if ne .Values.driver.httpsProxy "" }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.driver.httpsProxy }}
+            {{- end }}
+            {{- if ne .Values.driver.httpProxy "" }}
+            - name: HTTP_PROXY
+              value: {{ .Values.driver.httpProxy }}
+            {{- end }}
+            {{- if ne .Values.driver.noProxy "" }}
+            - name: NO_PROXY
+              value: {{ .Values.driver.noProxy }}
+            {{- end }}
           imagePullPolicy: {{ .Values.image.azuredisk.pullPolicy }}
           volumeMounts:
             - mountPath: /csi

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/deployment.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/deployment.yaml
@@ -27,7 +27,9 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
         {{- if .Values.controller.runOnMaster}}
-        node-role.kubernetes.io/control-plane: ""
+        {{-  range $key, $value := $.Values.controller.masterNodeSelector }}
+        {{ $key }}: {{ $value }}
+        {{- end}}
         {{- end}}
       priorityClassName: system-cluster-critical
 {{- with .Values.controller.tolerations }}
@@ -149,7 +151,7 @@ spec:
             periodSeconds: 30
           env:
             - name: AZURE_CREDENTIAL_FILE
-              value: /etc/kubernetes/config/azure.yaml
+              value: {{ .Values.linux.azure_credential_file }}
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             {{- if and $proxy.noProxy $proxy.http $proxy.https }}

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/deployment.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $proxy := deepCopy .Values.cluster.proxy |  mustMerge .Values.proxy }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -151,17 +152,19 @@ spec:
               value: /etc/kubernetes/config/azure.yaml
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-            {{- if ne .Values.driver.httpsProxy "" }}
-            - name: HTTPS_PROXY
-              value: {{ .Values.driver.httpsProxy }}
-            {{- end }}
-            {{- if ne .Values.driver.httpProxy "" }}
-            - name: HTTP_PROXY
-              value: {{ .Values.driver.httpProxy }}
-            {{- end }}
-            {{- if ne .Values.driver.noProxy "" }}
+            {{- if and $proxy.noProxy $proxy.http $proxy.https }}
             - name: NO_PROXY
-              value: {{ .Values.driver.noProxy }}
+              value: {{ $proxy.noProxy }}
+            - name: no_proxy
+              value: {{ $proxy.noProxy }}
+            - name: HTTP_PROXY
+              value: {{ $proxy.http }}
+            - name: http_proxy
+              value: {{ $proxy.http }}
+            - name: HTTPS_PROXY
+              value: {{ $proxy.https }}
+            - name: https_proxy
+              value: {{ $proxy.https }}
             {{- end }}
           imagePullPolicy: {{ .Values.image.azuredisk.pullPolicy }}
           volumeMounts:

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-node/daemonset.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-node/daemonset.yaml
@@ -109,6 +109,18 @@ spec:
               value: /etc/kubernetes/config/azure.yaml
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
+            {{- if ne .Values.driver.httpsProxy "" }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.driver.httpsProxy }}
+            {{- end }}
+            {{- if ne .Values.driver.httpProxy "" }}
+            - name: HTTP_PROXY
+              value: {{ .Values.driver.httpProxy }}
+            {{- end }}
+            {{- if ne .Values.driver.noProxy "" }}
+            - name: NO_PROXY
+              value: {{ .Values.driver.noProxy }}
+            {{- end }}
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-node/daemonset.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-node/daemonset.yaml
@@ -107,7 +107,7 @@ spec:
             periodSeconds: 30
           env:
             - name: AZURE_CREDENTIAL_FILE
-              value: /etc/kubernetes/config/azure.yaml
+              value: {{ .Values.linux.azure_credential_file }}
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             {{- if and $proxy.noProxy $proxy.http $proxy.https }}

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-node/daemonset.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-node/daemonset.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.linux.enabled}}
+{{- $proxy := deepCopy .Values.cluster.proxy |  mustMerge .Values.proxy }}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -109,17 +110,19 @@ spec:
               value: /etc/kubernetes/config/azure.yaml
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-            {{- if ne .Values.driver.httpsProxy "" }}
-            - name: HTTPS_PROXY
-              value: {{ .Values.driver.httpsProxy }}
-            {{- end }}
-            {{- if ne .Values.driver.httpProxy "" }}
-            - name: HTTP_PROXY
-              value: {{ .Values.driver.httpProxy }}
-            {{- end }}
-            {{- if ne .Values.driver.noProxy "" }}
+            {{- if and $proxy.noProxy $proxy.http $proxy.https }}
             - name: NO_PROXY
-              value: {{ .Values.driver.noProxy }}
+              value: {{ $proxy.noProxy }}
+            - name: no_proxy
+              value: {{ $proxy.noProxy }}
+            - name: HTTP_PROXY
+              value: {{ $proxy.http }}
+            - name: http_proxy
+              value: {{ $proxy.http }}
+            - name: HTTPS_PROXY
+              value: {{ $proxy.https }}
+            - name: https_proxy
+              value: {{ $proxy.https }}
             {{- end }}
             - name: KUBE_NODE_NAME
               valueFrom:

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-node/rbac.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-node/rbac.yaml
@@ -8,6 +8,9 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
   - apiGroups:
     - extensions
     resources:

--- a/helm/azuredisk-csi-driver-app/values.yaml
+++ b/helm/azuredisk-csi-driver-app/values.yaml
@@ -52,6 +52,8 @@ controller:
   livenessProbe:
     healthPort: 29602
   runOnMaster: false
+  masterNodeSelector:
+    "kubernetes.io/role": master
   disableAvailabilitySetNodes: true
   provisionerWorkerThreads: 100
   attacherWorkerThreads: 500
@@ -157,6 +159,7 @@ driver:
 linux:
   enabled: true
   dsName: csi-azuredisk-node
+  azure_credential_file: /etc/kubernetes/config/azure.yaml
   kubelet: /var/lib/kubelet
   enablePerfOptimization: true
   tolerations:

--- a/helm/azuredisk-csi-driver-app/values.yaml
+++ b/helm/azuredisk-csi-driver-app/values.yaml
@@ -153,9 +153,6 @@ driver:
   volumeAttachLimit: -1
   customUserAgent: ""
   userAgentSuffix: "giantswarm"
-  httpsProxy: ""
-  httpProxy: ""
-  noProxy: ""
 
 linux:
   enabled: true
@@ -197,6 +194,19 @@ linux:
         memory: 20Mi
 
 cloud: AzurePublicCloud
+
+# set the HTTP_PROXY, HTTPS_PROXY and NO_PROXY variable
+proxy:
+  noProxy:
+  http:
+  https:
+cluster:
+  # is getting overwritten by the top level proxy if set
+  # These values are generated via cluster-apps-operator
+  proxy:
+    noProxy:
+    http:
+    https:
 
 test:
   image:

--- a/helm/azuredisk-csi-driver-app/values.yaml
+++ b/helm/azuredisk-csi-driver-app/values.yaml
@@ -9,7 +9,7 @@ image:
   baseRepo: quay.io/giantswarm/
   azuredisk:
     repository: azuredisk-csi
-    tag: v1.21.0
+    tag: v1.25.0
     pullPolicy: IfNotPresent
   csiProvisioner:
     repository: csi-provisioner
@@ -53,7 +53,7 @@ controller:
     healthPort: 29602
   runOnMaster: false
   disableAvailabilitySetNodes: true
-  provisionerWorkerThreads: 40
+  provisionerWorkerThreads: 100
   attacherWorkerThreads: 500
   logLevel: 5
   tolerations:
@@ -61,6 +61,9 @@ controller:
       operator: "Exists"
       effect: "NoSchedule"
     - key: "node-role.kubernetes.io/controlplane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/control-plane"
       operator: "Exists"
       effect: "NoSchedule"
   hostNetwork: true
@@ -150,6 +153,9 @@ driver:
   volumeAttachLimit: -1
   customUserAgent: ""
   userAgentSuffix: "giantswarm"
+  httpsProxy: ""
+  httpProxy: ""
+  noProxy: ""
 
 linux:
   enabled: true


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/24865

- Bumped `azuredisk-csi` to upstream version 1.25.0
- Increased qps limits for csi-provisioner and csi-attacher to match upstream
- Increased WorkerThreads for csi-provisioner to match upstream
- Increased csi-attacher timeout from 600s to 1200s to match upstream
- Add support for http/s proxy settings to azuredisk
- as per [KEP 2067](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md#renaming-the-node-rolekubernetesiomaster-node-label) add toleration for `node-role.kubernetes.io/control-plane` label and update nodeSelector
- add rbac to get nodes for azuredisk-node to match upstream
- Make some hardcoded fields in the template a value so that we can set them differently in `Vintage` and in `CAPZ`
  - runOnMaster nodeSelector label
  - AZURE_CREDENTIAL_FILE location

---
Summary of Changes from upstream project
#### 1.22

* chart: As per [KEP 2067](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md), `node-role.kubernetes.io/master` taint is replaced with `node-role.kubernetes.io/control-plane`
* Bugfix for default iops on UltraSSD disks

#### 1.23

* support PremiumV2_LRS disk type
* support location in storage class
* chart: support http/s proxy settings
* increase csi-attaccher timeout

#### 1.24

* chart: increase client QPS settings for csi-attacher , csi-provisioner

#### 1.25
* support advanced perf profile on linux nodes
* chart: add no_proxy settings

--- 
ToDo:
  - [x] Check `node-role.kubernetes.io/control-plane` on a Workload Cluster azure vintage that the label is set on master node 
    - Vintage MC cluster do have the label but WC do not. i will make this a value in the values.yaml and default to old value
  - [x] Check `node-role.kubernetes.io/control-plane` on _glippy_ that label is set on master node
  - [x]  Check location and contents of `AZURE_CREDENTIAL_FILE` in vintage vs Capz
    - vintage: /etc/kubernetes/config/azure.yaml
    - capz: /etc/kubernetes/azure.json
    - [x] Support having different values for `AZURE_CREDENTIAL_FILE` in _vintage_ vs _capz_

---
Tests:
- [x] Vintage WC - on Godsmack
  - [x] Check Rendered Yaml `helm get manifest` and compare to current version
  - [x] Create Volume
  - [x] Delete volume
  - [x] Create Snapshot
  - [x] Restore Snapshot
- [x] CAPZ 
  - [x] Create Volume
  - [x] Delete Volume
  - [x] Create Snapshot
  - [x] Restore Snapshot

   
