### PR TITLE
Add StorageClass and VolumeSnapshotClass for CAPZ Clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+* Add StorageClasses for CSI Disk Driver , only enabled for CAPZ Clusters
+* Add VolumeSnapshotClass for CSI Disk Driver , only enabled for CAPZ Clusters
+
 ## [1.25.0-gs1] - 2022-12-06
 
 ### Changed

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/storage-class.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/storage-class.yaml
@@ -2,7 +2,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: default
+  name: managed-premium
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: disk.csi.azure.com
@@ -17,22 +17,7 @@ reclaimPolicy: Delete
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: managed-premium
-  annotations:
-provisioner: disk.csi.azure.com
-parameters:
-  cachingMode: ReadOnly
-  kind: managed
-  skuname: Premium_LRS
-allowVolumeExpansion: true
-volumeBindingMode: WaitForFirstConsumer
-reclaimPolicy: Delete
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
   name: managed-standard
-  annotations:
 provisioner: disk.csi.azure.com
 parameters:
   cachingMode: ReadOnly
@@ -41,4 +26,32 @@ parameters:
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: managed-premium-retain
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: disk.csi.azure.com
+parameters:
+  cachingMode: ReadOnly
+  kind: managed
+  skuname: Premium_LRS
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Retain
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: managed-standard-retain
+provisioner: disk.csi.azure.com
+parameters:
+  cachingMode: ReadOnly
+  kind: managed
+  skuname: Standard_LRS
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Retain
 {{- end }}

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/storage-class.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/storage-class.yaml
@@ -31,8 +31,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: managed-premium-retain
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: disk.csi.azure.com
 parameters:
   cachingMode: ReadOnly

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/storage-class.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/storage-class.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.provider (eq .Values.provider "capz") -}}
+kind: StorageClass
+metadata:
+  name: default
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: disk.csi.azure.com
+parameters:
+  cachingMode: ReadOnly
+  kind: managed
+  skuname: Premium_LRS
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: managed-premium
+  annotations:
+provisioner: disk.csi.azure.com
+parameters:
+  cachingMode: ReadOnly
+  kind: managed
+  skuname: Premium_LRS
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: managed-standard
+  annotations:
+provisioner: disk.csi.azure.com
+parameters:
+  cachingMode: ReadOnly
+  kind: managed
+  skuname: Standard_LRS
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+{{- end }}

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/storage-class.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/storage-class.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.provider (eq .Values.provider "capz") -}}
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: default

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/storage-class.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/storage-class.yaml
@@ -13,43 +13,4 @@ parameters:
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: managed-standard
-provisioner: disk.csi.azure.com
-parameters:
-  cachingMode: ReadOnly
-  kind: managed
-  skuname: Standard_LRS
-allowVolumeExpansion: true
-volumeBindingMode: WaitForFirstConsumer
-reclaimPolicy: Delete
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: managed-premium-retain
-provisioner: disk.csi.azure.com
-parameters:
-  cachingMode: ReadOnly
-  kind: managed
-  skuname: Premium_LRS
-allowVolumeExpansion: true
-volumeBindingMode: WaitForFirstConsumer
-reclaimPolicy: Retain
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: managed-standard-retain
-provisioner: disk.csi.azure.com
-parameters:
-  cachingMode: ReadOnly
-  kind: managed
-  skuname: Standard_LRS
-allowVolumeExpansion: true
-volumeBindingMode: WaitForFirstConsumer
-reclaimPolicy: Retain
 {{- end }}

--- a/helm/azuredisk-csi-driver-app/templates/snapshot-controller/snapshot-class.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/snapshot-controller/snapshot-class.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.snapshot.enabled .Values.provider (eq .Values.provider "capz") -}}
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-azuredisk
+driver: disk.csi.azure.com
+deletionPolicy: Delete
+parameters:
+  incremental: "true"
+{{- end }}


### PR DESCRIPTION
It does only affect CAPZ since in Vintage Azure the classes are created by the [Azure-Operator](https://github.com/giantswarm/azure-operator/blob/ec7870a87ad5ce4565649c73f53b9637ee64e1b5/service/controller/templates/ignition/default_storage_class.go)
