### PR TITLE
Updates to match upstream helm 1.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+- updates to match upstream helm 1.26.2
+  - Bumped `azuredisk-csi` to upstream version 1.26.2
+  - Bumped `csi-provisioner` to upstream version 3.3.0
+  - Bumped `csi-attacher` to upstream version 4.0.0
+  - Bumped `csi-resizer` to upstream version 1.6.0
+  - Bumped `liveness-probe` to upstream version 2.8.0
+  - Bumped `nodeDriverRegistrar` to upstream version 2.6.2
+  - increase csi-provisioner timeout to 30s
+
 ## [1.25.2-gs1] - 2022-12-22
 
 * Remove VolumeSnapshotClass since we need to first install the CRDs as a hook before we can push this manifest

--- a/helm/azuredisk-csi-driver-app/Chart.yaml
+++ b/helm/azuredisk-csi-driver-app/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
-appVersion: 1.25.0
+appVersion: 1.26.2
 description: A Helm chart to run Azure CSI driver for Azure Disks.
 icon: https://s.giantswarm.io/app-icons/azure/1/dark.svg
 home: https://github.com/giantswarm/azuredisk-csi-driver-app
 name: azuredisk-csi-driver-app
-version: [[ .Version ]]
+version: 0.0.0-dev
 restrictions:
   clusterSingleton: true
   fixedNamespace: kube-system

--- a/helm/azuredisk-csi-driver-app/Chart.yaml
+++ b/helm/azuredisk-csi-driver-app/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to run Azure CSI driver for Azure Disks.
 icon: https://s.giantswarm.io/app-icons/azure/1/dark.svg
 home: https://github.com/giantswarm/azuredisk-csi-driver-app
 name: azuredisk-csi-driver-app
-version: 0.0.0-dev
+version: [[ .Version ]]
 restrictions:
   clusterSingleton: true
   fixedNamespace: kube-system

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/deployment.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - "--feature-gates=Topology=true"
             - "--csi-address=$(ADDRESS)"
             - "--v=2"
-            - "--timeout=15s"
+            - "--timeout=30s"
             - "--leader-election"
             - "--leader-election-namespace={{ .Release.Namespace }}"
             - "--worker-threads={{ .Values.controller.provisionerWorkerThreads }}"

--- a/helm/azuredisk-csi-driver-app/values.yaml
+++ b/helm/azuredisk-csi-driver-app/values.yaml
@@ -9,27 +9,27 @@ image:
   baseRepo: quay.io/giantswarm/
   azuredisk:
     repository: azuredisk-csi
-    tag: v1.25.0
+    tag: v1.26.2
     pullPolicy: IfNotPresent
   csiProvisioner:
     repository: csi-provisioner
-    tag: v3.2.1
+    tag: v3.3.0
     pullPolicy: IfNotPresent
   csiAttacher:
     repository: csi-attacher
-    tag: v3.5.0
+    tag: v4.0.0
     pullPolicy: IfNotPresent
   csiResizer:
     repository: csi-resizer
-    tag: v1.5.0
+    tag: v1.6.0
     pullPolicy: IfNotPresent
   livenessProbe:
     repository: livenessprobe
-    tag: v2.7.0
+    tag: v2.8.0
     pullPolicy: IfNotPresent
   nodeDriverRegistrar:
     repository: csi-node-driver-registrar
-    tag: v2.5.1
+    tag: v2.6.2
     pullPolicy: IfNotPresent
 
 serviceAccount:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24587

- Upgrade all components to match upstream 1.26.2 helm chart

