### PR TITLE
Disable PSPs for k8s 1.25 and newer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Disable PSPs for k8s 1.25 and newer.
+
 ## [1.26.2-gs1] - 2023-02-15
 
 ### Changed

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/psp.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/psp.yaml
@@ -1,3 +1,4 @@
+{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -36,3 +37,4 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-node/psp.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-node/psp.yaml
@@ -1,3 +1,4 @@
+{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -33,3 +34,4 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}


### PR DESCRIPTION
in k8s 1.25 there is no PodSecurityPolicy

this PR disables the PSP for 1.25