### PR TITLE
Update PolicyExceptions to v2beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update Kyverno PolicyExceptions to `v2` and fallback to `v2beta1`.
+
 ## [1.26.2-gs6] - 2024-01-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Update Kyverno PolicyExceptions to `v2` and fallback to `v2beta1`.
 - Bump upstream version to v1.30.2.
 
-
 ## [1.26.2-gs6] - 2024-01-23
 
 ### Added

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/pss-exceptions.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-controller/pss-exceptions.yaml
@@ -1,5 +1,9 @@
-{{ if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" -}}
-apiVersion: kyverno.io/v2alpha1
+{{ if .Capabilities.APIVersions.Has "kyverno.io/v2beta1/PolicyException" -}}
+{{ if .Capabilities.APIVersions.Has "kyverno.io/v2/PolicyException" -}}
+apiVersion: kyverno.io/v2
+{{- else }}
+apiVersion: kyverno.io/v2beta1
+{{- end }}
 kind: PolicyException
 metadata:
   name: {{ .Values.controller.name }}-exceptions

--- a/helm/azuredisk-csi-driver-app/templates/azuredisk-node/pss-exceptions.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/azuredisk-node/pss-exceptions.yaml
@@ -1,5 +1,9 @@
-{{ if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" -}}
-apiVersion: kyverno.io/v2alpha1
+{{ if .Capabilities.APIVersions.Has "kyverno.io/v2beta1/PolicyException" -}}
+{{ if .Capabilities.APIVersions.Has "kyverno.io/v2/PolicyException" -}}
+apiVersion: kyverno.io/v2
+{{- else }}
+apiVersion: kyverno.io/v2beta1
+{{- end }}
 kind: PolicyException
 metadata:
   name: {{ .Values.linux.dsName }}-exceptions

--- a/helm/azuredisk-csi-driver-app/templates/snapshot-controller/pss-exceptions.yaml
+++ b/helm/azuredisk-csi-driver-app/templates/snapshot-controller/pss-exceptions.yaml
@@ -1,5 +1,9 @@
-{{ if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" -}}
-apiVersion: kyverno.io/v2alpha1
+{{ if .Capabilities.APIVersions.Has "kyverno.io/v2beta1/PolicyException" -}}
+{{ if .Capabilities.APIVersions.Has "kyverno.io/v2/PolicyException" -}}
+apiVersion: kyverno.io/v2
+{{- else }}
+apiVersion: kyverno.io/v2beta1
+{{- end }}
 kind: PolicyException
 metadata:
   name: {{ .Values.snapshot.snapshotController.name }}-exceptions


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.