### PR TITLE
Migrate to App Build Suite (ABS)

### DIFF
--- a/.abs/.kube-linter.yaml
+++ b/.abs/.kube-linter.yaml
@@ -1,0 +1,18 @@
+checks:
+  exclude:
+    # CSI drivers require hostNetwork for kubelet communication
+    - "host-network"
+    # CSI node daemonset requires privileged access for disk mounting operations
+    - "privileged-container"
+    - "privilege-escalation-container"
+    # CSI drivers need to run as root for disk operations
+    - "run-as-non-root"
+    # CSI drivers need writable filesystem for socket and state management
+    - "no-read-only-root-fs"
+    # CSI node requires access to /dev for block device operations
+    - "sensitive-host-mounts"
+    # When using hostNetwork, explicit containerPort declarations aren't required
+    - "liveness-port"
+    # Anti-affinity is configured via topology constraints, not pod anti-affinity
+    - "no-anti-affinity"
+

--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -3,4 +3,5 @@ generate-metadata: true
 chart-dir: ./helm/azuredisk-csi-driver-app
 destination: build
 catalog-base-url: https://giantswarm.github.io/control-plane-catalog/
+kubelinter-config: .abs/.kube-linter.yaml
 

--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -1,0 +1,6 @@
+replace-chart-version-with-git: true
+generate-metadata: true
+chart-dir: ./helm/azuredisk-csi-driver-app
+destination: build
+catalog-base-url: https://giantswarm.github.io/control-plane-catalog/
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ workflows:
     jobs:
     - architect/push-to-app-catalog:
         context: architect
+        executor: app-build-suite
         name: push-to-control-plane-app-catalog
         app_catalog: control-plane-catalog
         app_catalog_test: control-plane-test-catalog
@@ -22,6 +23,7 @@ workflows:
             - master
     - architect/push-to-app-catalog:
         context: architect
+        executor: app-build-suite
         name: push-to-default-app-catalog
         app_catalog: default-catalog
         app_catalog_test: default-test-catalog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate to App Build Suite (ABS).
+
 ## [2.1.0] - 2026-01-19
 
 ### Changed

--- a/helm/azuredisk-csi-driver-app/Chart.yaml
+++ b/helm/azuredisk-csi-driver-app/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to run Azure CSI driver for Azure Disks.
 icon: https://s.giantswarm.io/app-icons/azure/1/dark.svg
 home: https://github.com/giantswarm/azuredisk-csi-driver-app
 name: azuredisk-csi-driver-app
-version: [[ .Version ]]
+version: 2.1.0-dev
 restrictions:
   clusterSingleton: true
   fixedNamespace: kube-system
@@ -12,3 +12,4 @@ restrictions:
   compatibleProviders: [azure]
 annotations:
   application.giantswarm.io/team: phoenix
+  io.giantswarm.application.team: phoenix

--- a/helm/azuredisk-csi-driver-app/Chart.yaml
+++ b/helm/azuredisk-csi-driver-app/Chart.yaml
@@ -11,5 +11,4 @@ restrictions:
   gpuInstances: false
   compatibleProviders: [azure]
 annotations:
-  application.giantswarm.io/team: phoenix
   io.giantswarm.application.team: phoenix

--- a/helm/azuredisk-csi-driver-app/templates/_helpers.tpl
+++ b/helm/azuredisk-csi-driver-app/templates/_helpers.tpl
@@ -16,7 +16,7 @@ app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 app.kubernetes.io/name: "{{ template "azuredisk.name" . }}"
 app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
 helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | quote }}
 {{- end -}}
 
 {{/* pull secrets for containers */}}

--- a/helm/azuredisk-csi-driver-app/values.schema.json
+++ b/helm/azuredisk-csi-driver-app/values.schema.json
@@ -1,0 +1,80 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "serviceType": {
+            "type": "string"
+        },
+        "image": {
+            "type": "object"
+        },
+        "serviceAccount": {
+            "type": "object"
+        },
+        "rbac": {
+            "type": "object"
+        },
+        "controller": {
+            "type": "object"
+        },
+        "node": {
+            "type": "object"
+        },
+        "snapshot": {
+            "type": "object"
+        },
+        "feature": {
+            "type": "object"
+        },
+        "driver": {
+            "type": "object"
+        },
+        "linux": {
+            "type": "object"
+        },
+        "cloud": {
+            "type": "string"
+        },
+        "proxy": {
+            "type": "object"
+        },
+        "cluster": {
+            "type": "object"
+        },
+        "imagePullSecrets": {
+            "type": "array"
+        },
+        "workloadIdentity": {
+            "type": "object"
+        },
+        "azureCredentialFileConfigMap": {
+            "type": "string"
+        },
+        "test": {
+            "type": "object"
+        },
+        "podSecurityContext": {
+            "type": "object"
+        },
+        "securityContext": {
+            "type": "object"
+        },
+        "global": {
+            "type": "object",
+            "properties": {
+                "podSecurityStandards": {
+                    "type": "object",
+                    "properties": {
+                        "enforced": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
This PR migrates the repository to use App Build Suite (ABS) for building and publishing Helm charts.

## Changes

- Add `executor: app-build-suite` to CircleCI config
- Create `.abs/main.yaml` with ABS configuration
- Update `Chart.yaml`:
  - Replace version placeholder with `2.1.0-dev`
  - Add `io.giantswarm.application.team` annotation (OpenContainers format)
- Update `CHANGELOG.md`

Note: `replace-app-version-with-git` is NOT set because this is an upstream app where `appVersion` reflects the upstream version (1.33.7).